### PR TITLE
Remove i18n configuration and simplify JSP content

### DIFF
--- a/src/main/java/com/fd/mvc/controller/HomeController.java
+++ b/src/main/java/com/fd/mvc/controller/HomeController.java
@@ -2,44 +2,28 @@ package com.fd.mvc.controller;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.context.MessageSource;
-import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 
 import java.time.LocalTime;
-import java.util.Locale;
 
 //import static com.fd.mvc.common.Constants.VIEW_HOME_CONTROLLER;
 
 @Controller
 public class HomeController {
 
-    private final MessageSource messageSource;
     private static final Logger log = LoggerFactory.getLogger(HomeController.class);
 
-    public HomeController(MessageSource messageSource) {
-        this.messageSource = messageSource;
-    }
-
     @RequestMapping(value = "/", method = RequestMethod.GET)
-    public String home(Locale locale, Model model) {
+    public String home(Model model) {
 
         log.debug("Getting home page");
-        log.info("Welcome home! The client locale is {}.", locale);
 
-        //-----Parameterized ------- http://memorynotfound.com/spring-mvc-internationalization-i18n-example/
-        String welcome = messageSource.getMessage("welcome.message", new Object[]{"Buenos días"}, locale);
-        model.addAttribute("message", welcome);
-
-        // obtain locale from LocaleContextHolder
-        Locale currentLocale = LocaleContextHolder.getLocale();
-        model.addAttribute("locale", currentLocale);
+        model.addAttribute("message", "Hola, Buenos días");
 
         model.addAttribute("startMeeting", LocalTime.now());
-        //-----Parameterized ---------- http://memorynotfound.com/spring-mvc-internationalization-i18n-example/
 
 //        return VIEW_HOME_CONTROLLER;
         return "home";

--- a/src/main/resources/WebConfig.java
+++ b/src/main/resources/WebConfig.java
@@ -1,22 +1,15 @@
 package com.fd.mvc.config;
 
-import org.springframework.context.MessageSource;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.support.ReloadableResourceBundleMessageSource;
 import org.springframework.web.servlet.config.annotation.*;
-import org.springframework.web.servlet.i18n.CookieLocaleResolver;
-import org.springframework.web.servlet.i18n.LocaleChangeInterceptor;
 import org.springframework.web.servlet.view.tiles3.TilesConfigurer;
 import org.springframework.web.servlet.view.tiles3.TilesViewResolver;
-
-import java.util.Locale;
 
 @EnableWebMvc
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
 
-    private static final String MESSAGE_SOURCE = "/WEB-INF/i18n/messages";
     private static final String RESOURCES_LOCATION = "/resources/";
     private static final String RESOURCES_HANDLER = RESOURCES_LOCATION + "**";
 
@@ -40,34 +33,6 @@ public class WebConfig implements WebMvcConfigurer {
         registry.viewResolver(viewResolver);
     }
 
-    @Bean(name = "messageSource")
-    public MessageSource messageSource() {
-        ReloadableResourceBundleMessageSource messageSource = new ReloadableResourceBundleMessageSource();
-        messageSource.setBasename(MESSAGE_SOURCE);
-        messageSource.setCacheSeconds(5);
-        return messageSource;
-    }
-
-    @Bean
-    public CookieLocaleResolver localeResolver() {
-        CookieLocaleResolver localeResolver = new CookieLocaleResolver();
-        localeResolver.setDefaultLocale(Locale.ENGLISH);
-        localeResolver.setCookieName("my-locale-cookie");
-        localeResolver.setCookieMaxAge(3600);
-        return localeResolver;
-    }
-
-    @Bean
-    public LocaleChangeInterceptor localeInterceptor() {
-        LocaleChangeInterceptor interceptor = new LocaleChangeInterceptor();
-        interceptor.setParamName("lang");
-        return interceptor;
-    }
-
-    @Override
-    public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(localeInterceptor());
-    }
 
     /**
      * Configure ResourceHandlers to serve static resources like CSS/ Javascript etc...

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,10 +10,6 @@ spring:
         view:
             prefix: /WEB-INF/views/
             suffix: .jsp
-    messages:
-        basename: i18n/messages
-        encoding: UTF-8
-        fallback-to-system-locale: false
 
     datasource:
         url: jdbc:mysql://localhost:3306/hibernate_adminSpringMVC?allowPublicKeyRetrieval=true&useSSL=false&serverTimezone=UTC&useCursors=false&sendStringParametersAsUnicode=false&characterEncoding=UTF8

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -1,3 +1,0 @@
-welcome.message = Hola, {0}
-welcome.greeting = Mucho gustooo {0}.
-label_homepage=Home

--- a/src/main/resources/i18n/messages_en.properties
+++ b/src/main/resources/i18n/messages_en.properties
@@ -1,3 +1,0 @@
-welcome.message = Hello, {0}
-welcome.greeting = Nice that you could join the meeting. We begin at {0}.
-label_homepage=Home

--- a/src/main/resources/i18n/messages_es.properties
+++ b/src/main/resources/i18n/messages_es.properties
@@ -1,3 +1,0 @@
-welcome.message = Hola, {0}
-welcome.greeting = Es bueno que puedas unirte a la reunión. Comenzamos a las {0}.
-label_homepage=Inicio

--- a/src/main/resources/i18n/messages_es_MX.properties
+++ b/src/main/resources/i18n/messages_es_MX.properties
@@ -1,3 +1,0 @@
-welcome.message=¡Buenos días desde es_MX!
-welcome.greeting = Mucho gustooo {0}.
-label_homepage=Home

--- a/src/main/resources/i18n/messages_fr.properties
+++ b/src/main/resources/i18n/messages_fr.properties
@@ -1,3 +1,0 @@
-welcome.message = Bonjour, {0}
-welcome.greeting = Belle que vous pourriez participer à la réunion. Nous commençons à {0}.
-label_homepage=Accueil

--- a/src/main/webapp/WEB-INF/views/pages/exercises/viewPalindrome.jsp
+++ b/src/main/webapp/WEB-INF/views/pages/exercises/viewPalindrome.jsp
@@ -1,7 +1,6 @@
 <%@ page contentType="text/html" pageEncoding="UTF-8"%>
 <%@ taglib prefix="form" uri="http://www.springframework.org/tags/form" %>
-<%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
-	<p><spring:message code="lbl.validatePalindromo" text="Validar Palindromo" /></p>
+        <p>Validar Palíndromo</p>
 	<div class="ui form">
 		<form:form id="palindromeForm" action="viewPalindrome" method="post" modelAttribute="palindromeSearchCriteria" >
 			<div class="ten wide field">

--- a/src/main/webapp/WEB-INF/views/pages/home.jsp
+++ b/src/main/webapp/WEB-INF/views/pages/home.jsp
@@ -1,10 +1,7 @@
-<%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
+<%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 <img src="${pageContext.request.contextPath}/resources/images/spring-logo.png">
 
-<h1>Spring Boot Internacionalización i18n Ejemplo</h1>
-Lenguaje : <a href="?lang=en">Ingles</a> | <a href="?lang=es">Español</a> | <a href="?lang=fr">Frances</a>
+<h1>Ejemplo de Spring Boot</h1>
 <p>${message}</p>
-<p><spring:message code="welcome.greeting" arguments="${startMeeting}"/></p>
-Current Locale : ${pageContext.response.locale} / ${locale}
+<p>Comenzamos la reuniÃ³n a las ${startMeeting}</p>
 
-<p><spring:message code="label_homepage" text="Inicio" /></p>

--- a/src/main/webapp/WEB-INF/views/pages/modules/finance/payments/formPayment.jsp
+++ b/src/main/webapp/WEB-INF/views/pages/modules/finance/payments/formPayment.jsp
@@ -1,9 +1,8 @@
 <%@ taglib prefix="form" uri="http://www.springframework.org/tags/form" %>
-<%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
-	<form:form id="formPayment" action="formPayment" method="post" modelAttribute="paymentSearchCriteria">
-		
-		<p><spring:message code="module.finance.payments.lblPayment" text="Payment" /></p>
+        <form:form id="formPayment" action="formPayment" method="post" modelAttribute="paymentSearchCriteria">
+
+                <p>Pago</p>
 		<p class="msgResult">${msgResult}</p>
 		<form:errors path="*" cssClass="errorDiv" element="div"/>
 		


### PR DESCRIPTION
## Summary
- delete i18n property files and configuration
- remove locale handling from `WebConfig` and `HomeController`
- simplify JSP pages with Spanish text

## Testing
- `mvn -q package` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684a6ca6cc90832e91e758a6cf0ac318