### PR TITLE
Fix dynamic header for Thymeleaf pages

### DIFF
--- a/src/main/resources/resources/js/simple-test.js
+++ b/src/main/resources/resources/js/simple-test.js
@@ -1,10 +1,5 @@
 $(function(){
-	
-	/**
-	 * Example: Home > View Tiwilio SMS
-	 */
-	$('#btitle').html($('title').html());
-	
+        // Common javascript initialization can go here
 });
 
 /**

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -4,7 +4,7 @@
     <title>Home</title>
 </head>
 <body>
-<div th:replace="includes/header :: header"></div>
+<div th:replace="~{includes/header :: header(pageTitle='Home')}"></div>
 <img th:src="@{/resources/images/spring-logo.png}" />
 <h1>Ejemplo de Spring Boot</h1>
 <p th:text="${message}"></p>

--- a/src/main/resources/templates/includes/header.html
+++ b/src/main/resources/templates/includes/header.html
@@ -1,4 +1,4 @@
-<div th:fragment="header">
+<div th:fragment="header(pageTitle)">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.1.7/semantic.min.js"></script>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.1.7/semantic.min.css" rel="stylesheet" type="text/css"/>
@@ -11,5 +11,5 @@
     <link href="https://cdnjs.cloudflare.com/ajax/libs/datatables/1.10.15/css/dataTables.jqueryui.min.css" rel="stylesheet" type="text/css" />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/datatables/1.10.15/js/jquery.dataTables.min.js"></script>
 
-    <div th:replace="includes/navigatorHeader :: navigatorHeader"></div>
+    <div th:replace="~{includes/navigatorHeader :: navigatorHeader(pageTitle=${pageTitle})}"></div>
 </div>

--- a/src/main/resources/templates/includes/navigatorHeader.html
+++ b/src/main/resources/templates/includes/navigatorHeader.html
@@ -1,4 +1,4 @@
-<div class="mainMenu" th:fragment="navigatorHeader">
+<div class="mainMenu" th:fragment="navigatorHeader(pageTitle)">
     <div class="ui menu">
         <a th:href="@{/}" class="item"><i class="home icon"></i> Home </a>
         <a class="browse item">Browse <i class="dropdown icon"></i></a>
@@ -45,7 +45,7 @@
 </div>
 <div class="ui secondary menu">
     <div class="item">
-        <a th:href="@{/}">Home</a>&nbsp;>&nbsp;<a id="btitle" href="#"></a>
+        <a th:href="@{/}">Home</a>&nbsp;>&nbsp;<a id="btitle" th:text="${pageTitle}" href="#"></a>
     </div>
 </div>
 <script>

--- a/src/main/resources/templates/pages/api/viewMapBox.html
+++ b/src/main/resources/templates/pages/api/viewMapBox.html
@@ -4,7 +4,7 @@
     <title>MapBox</title>
 </head>
 <body>
-<div th:replace="includes/header :: header"></div>
+<div th:replace="~{includes/header :: header(pageTitle='MapBox')}"></div>
 <div>MapBox</div>
 <div th:replace="includes/footer :: footer"></div>
 </body>

--- a/src/main/resources/templates/pages/bitso/viewBitso.html
+++ b/src/main/resources/templates/pages/bitso/viewBitso.html
@@ -4,7 +4,7 @@
     <title>Bitso</title>
 </head>
 <body>
-<div th:replace="includes/header :: header"></div>
+<div th:replace="~{includes/header :: header(pageTitle='Bitso')}"></div>
 <div class="ui image label">
     <img th:src="@{/resources/images/criptoCurrency/ethereum.png}">
     <span th:text="${balanceTotalETH}"></span>

--- a/src/main/resources/templates/pages/bitso/viewBitsoCompra.html
+++ b/src/main/resources/templates/pages/bitso/viewBitsoCompra.html
@@ -4,7 +4,7 @@
     <title>Bitso Compra</title>
 </head>
 <body>
-<div th:replace="includes/header :: header"></div>
+<div th:replace="~{includes/header :: header(pageTitle='Bitso Compra')}"></div>
 <table id="example" class="ui celled table sortable">
     <thead>
         <tr>

--- a/src/main/resources/templates/pages/bitso/viewBitsoOrderBook.html
+++ b/src/main/resources/templates/pages/bitso/viewBitsoOrderBook.html
@@ -4,7 +4,7 @@
     <title>Bitso Order Book</title>
 </head>
 <body>
-<div th:replace="includes/header :: header"></div>
+<div th:replace="~{includes/header :: header(pageTitle='Bitso Order Book')}"></div>
 <table id="orderBookResultCompra" class="ui celled table sortable">
     <thead>
         <tr>

--- a/src/main/resources/templates/pages/criptoCurrency/mainCripto.html
+++ b/src/main/resources/templates/pages/criptoCurrency/mainCripto.html
@@ -4,7 +4,7 @@
     <title>CriptoCurrency</title>
 </head>
 <body>
-<div th:replace="includes/header :: header"></div>
+<div th:replace="~{includes/header :: header(pageTitle='CriptoCurrency')}"></div>
 <div class="ui form">
     <div class="ten wide field">
         <div class="field">

--- a/src/main/resources/templates/pages/email/viewSendEmailTest.html
+++ b/src/main/resources/templates/pages/email/viewSendEmailTest.html
@@ -4,7 +4,7 @@
     <title>Send Email Test</title>
 </head>
 <body>
-<div th:replace="includes/header :: header"></div>
+<div th:replace="~{includes/header :: header(pageTitle='Send Email Test')}"></div>
 <div class="ui form">
     <div class="ten wide field">
         <div class="field">

--- a/src/main/resources/templates/pages/exercises/viewJQuery3.html
+++ b/src/main/resources/templates/pages/exercises/viewJQuery3.html
@@ -4,7 +4,7 @@
     <title>jQuery Example</title>
 </head>
 <body>
-<div th:replace="includes/header :: header"></div>
+<div th:replace="~{includes/header :: header(pageTitle='jQuery Example')}"></div>
 <img title="Get Width/Height" style="cursor: pointer;" id="imgLogo" alt="spring-logo" th:src="@{/resources/images/spring-logo.png}">
 <div class="buttonsShowHide">
     <button id="showLogo">Mostar</button>

--- a/src/main/resources/templates/pages/exercises/viewPalindrome.html
+++ b/src/main/resources/templates/pages/exercises/viewPalindrome.html
@@ -4,7 +4,7 @@
     <title>View Palindrome</title>
 </head>
 <body>
-<div th:replace="includes/header :: header"></div>
+<div th:replace="~{includes/header :: header(pageTitle='View Palindrome')}"></div>
 <p>Validar Palíndromo</p>
 <div class="ui form">
     <form id="palindromeForm" th:action="@{/exercises/viewPalindrome}" method="post" th:object="${palindromeSearchCriteria}">

--- a/src/main/resources/templates/pages/exercises/viewSerializable.html
+++ b/src/main/resources/templates/pages/exercises/viewSerializable.html
@@ -4,7 +4,7 @@
     <title>Serializable Example</title>
 </head>
 <body>
-<div th:replace="includes/header :: header"></div>
+<div th:replace="~{includes/header :: header(pageTitle='Serializable Example')}"></div>
 <div class="ui form">
     <form th:action="@{/exercises/viewSerializable}" method="post" th:object="${serializableGeneralSearchCriteria}">
         <div class="ten wide field">

--- a/src/main/resources/templates/pages/googleMaps/placeAutocompleteAddressForm.html
+++ b/src/main/resources/templates/pages/googleMaps/placeAutocompleteAddressForm.html
@@ -4,7 +4,7 @@
     <title>Google Maps Autocomplete</title>
 </head>
 <body>
-<div th:replace="includes/header :: header"></div>
+<div th:replace="~{includes/header :: header(pageTitle='Google Maps Autocomplete')}"></div>
 <div id="locationField">
     <input id="autocomplete" placeholder="Enter your address" type="text" />
 </div>

--- a/src/main/resources/templates/pages/modules/finance/payments/formPayment.html
+++ b/src/main/resources/templates/pages/modules/finance/payments/formPayment.html
@@ -4,7 +4,7 @@
     <title>Form Payment</title>
 </head>
 <body>
-<div th:replace="includes/header :: header"></div>
+<div th:replace="~{includes/header :: header(pageTitle='Form Payment')}"></div>
 <form id="formPayment" th:action="@{/modules/finance/payments/formPayment}" method="post" th:object="${paymentSearchCriteria}">
     <p>Pago</p>
     <p class="msgResult" th:text="${msgResult}"></p>

--- a/src/main/resources/templates/pages/modules/finance/payments/viewPaymentes.html
+++ b/src/main/resources/templates/pages/modules/finance/payments/viewPaymentes.html
@@ -4,7 +4,7 @@
     <title>View Payments</title>
 </head>
 <body>
-<div th:replace="includes/header :: header"></div>
+<div th:replace="~{includes/header :: header(pageTitle='View Payments')}"></div>
 <div id="menuPayments">
     | <a th:href="@{/modules/finance/payments/formPayment}">Add</a> |
 </div>

--- a/src/main/resources/templates/pages/reports/viewJasperReport.html
+++ b/src/main/resources/templates/pages/reports/viewJasperReport.html
@@ -4,7 +4,7 @@
     <title>Jasper Report</title>
 </head>
 <body>
-<div th:replace="includes/header :: header"></div>
+<div th:replace="~{includes/header :: header(pageTitle='Jasper Report')}"></div>
 <h1>OK - subReport ---- check in : C:\tools</h1>
 <div th:replace="includes/footer :: footer"></div>
 </body>

--- a/src/main/resources/templates/pages/twilio/viewTwilioSMS.html
+++ b/src/main/resources/templates/pages/twilio/viewTwilioSMS.html
@@ -4,7 +4,7 @@
     <title>Twilio SMS</title>
 </head>
 <body>
-<div th:replace="includes/header :: header"></div>
+<div th:replace="~{includes/header :: header(pageTitle='Twilio SMS')}"></div>
 <div class="ui form">
     <form id="formTwilio" th:action="@{/twilio/viewTiwilioSMS}" method="post" th:object="${twilioSMSSearchCriteria}">
         <div class="ten wide field">

--- a/src/main/resources/templates/pages/utils/upload.html
+++ b/src/main/resources/templates/pages/utils/upload.html
@@ -4,7 +4,7 @@
     <title>Upload Files</title>
 </head>
 <body>
-<div th:replace="includes/header :: header"></div>
+<div th:replace="~{includes/header :: header(pageTitle='Upload Files')}"></div>
 <h1>Spring MVC multi files upload example</h1>
 <div class="ui form">
     <form method="POST" th:action="@{/uploadMulti}" th:object="${uploadForm}" enctype="multipart/form-data">

--- a/src/main/resources/templates/pages/utils/uploadStatus.html
+++ b/src/main/resources/templates/pages/utils/uploadStatus.html
@@ -4,7 +4,7 @@
     <title>Upload Status</title>
 </head>
 <body>
-<div th:replace="includes/header :: header"></div>
+<div th:replace="~{includes/header :: header(pageTitle='Upload Status')}"></div>
 <div>
     <h1>Upload Status</h1>
     <h2>Message : <span th:text="${message}"></span></h2>


### PR DESCRIPTION
## Summary
- make header fragment accept a `pageTitle` parameter
- display page title in navigator header
- remove old jQuery breadcrumb logic
- pass page title when including header across templates

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a8fba876c832ebaa615f86dd6abb1