### PR TITLE
Add Swagger to document controllers

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,20 @@ mvn package
 java -jar target/adminSpringBoot-0.0.1.jar
 ```
 
+## Documentación con Swagger
+
+Con la aplicación en ejecución puedes consultar y probar los endpoints desde el navegador accediendo a:
+
+```
+http://localhost:8080/web/common/swagger-ui.html
+```
+
+Por ejemplo, el controlador de Bitso expone la vista de libro de órdenes en:
+
+```
+http://localhost:8080/web/common/bitso/viewBitsoOrderBook
+```
+
 ## Requisitos
 
 Se necesita JDK 21 para compilar y ejecutar el proyecto.

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 		<hikaricp.version>5.1.0</hikaricp.version>
 	</properties>
 
-	<dependencies>
+        <dependencies>
 
 		<!-- Spring Web -->
 		<dependency>
@@ -136,15 +136,22 @@
 			<version>8.36.0</version>
 		</dependency>
 
-		<!-- Google Maps -->
-		<dependency>
-			<groupId>com.google.maps</groupId>
-			<artifactId>google-maps-services</artifactId>
-			<version>0.14.0</version>
-		</dependency>
+                <!-- Google Maps -->
+                <dependency>
+                        <groupId>com.google.maps</groupId>
+                        <artifactId>google-maps-services</artifactId>
+                        <version>0.14.0</version>
+                </dependency>
+
+                <!-- OpenAPI / Swagger -->
+                <dependency>
+                        <groupId>org.springdoc</groupId>
+                        <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+                        <version>2.5.0</version>
+                </dependency>
 
 
-	</dependencies>
+        </dependencies>
 
 	<build>
 		<plugins>

--- a/src/main/java/com/fd/mvc/config/OpenApiConfig.java
+++ b/src/main/java/com/fd/mvc/config/OpenApiConfig.java
@@ -1,0 +1,19 @@
+package com.fd.mvc.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI adminSpringBootOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("AdminSpringBoot API")
+                        .description("Documentación de los servicios disponibles")
+                        .version("1.0"));
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,3 +28,7 @@ mysql:
         maximum-pool-size: 5
         connection-test-query: SELECT 1 FROM DUAL
         pool-name: SpringBootHikariMySQL
+
+springdoc:
+    swagger-ui:
+        path: /swagger-ui.html


### PR DESCRIPTION
## Summary
- integrate springdoc-openapi to expose Swagger UI
- add an OpenAPI config with project information
- expose swagger-ui path in application.yml
- document swagger access in README

## Testing
- `mvn -q test` *(fails: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684af315eccc832eb97896a1d85cc5ab