### PR TITLE
Fix controllers visibility on Swagger

### DIFF
--- a/src/main/java/com/fd/mvc/config/OpenApiConfig.java
+++ b/src/main/java/com/fd/mvc/config/OpenApiConfig.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springdoc.core.models.GroupedOpenApi;
 
 @Configuration
 public class OpenApiConfig {
@@ -15,5 +16,13 @@ public class OpenApiConfig {
                         .title("AdminSpringBoot API")
                         .description("Documentación de los servicios disponibles")
                         .version("1.0"));
+    }
+
+    @Bean
+    public GroupedOpenApi controllersGroup() {
+        return GroupedOpenApi.builder()
+                .group("controllers")
+                .packagesToScan("com.fd.mvc.controller")
+                .build();
     }
 }


### PR DESCRIPTION
## Summary
- expose MVC controllers in Swagger using GroupedOpenApi configuration

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_684af50b374c832e8bfcfcfcf494857e