### PR TITLE
Add file details table in upload status page

### DIFF
--- a/src/main/java/com/fd/mvc/controller/UploadWebController.java
+++ b/src/main/java/com/fd/mvc/controller/UploadWebController.java
@@ -50,6 +50,7 @@ public class UploadWebController {
             redirectAttributes.addFlashAttribute("message", "Please select a file to upload");
         } else {
             redirectAttributes.addFlashAttribute("message", "You successfully uploaded '" + uploadedFileName + "'");
+            redirectAttributes.addFlashAttribute("files", storedFiles);
         }
 
         return "redirect:/uploadStatus";

--- a/src/main/java/com/fd/mvc/service/FileUploadResult.java
+++ b/src/main/java/com/fd/mvc/service/FileUploadResult.java
@@ -7,5 +7,6 @@ import java.nio.file.Path;
  *
  * @param fileName original name of the uploaded file
  * @param location final storage location
+ * @param fileSize size of the uploaded file in bytes
  */
-public record FileUploadResult(String fileName, Path location) { }
+public record FileUploadResult(String fileName, Path location, long fileSize) { }

--- a/src/main/java/com/fd/mvc/service/impl/FileStorageServiceImpl.java
+++ b/src/main/java/com/fd/mvc/service/impl/FileStorageServiceImpl.java
@@ -40,7 +40,10 @@ public class FileStorageServiceImpl implements FileStorageService {
                 Files.createDirectories(uploadDir);
                 Path destination = uploadDir.resolve(file.getOriginalFilename());
                 Files.write(destination, file.getBytes());
-                results.add(new FileUploadResult(file.getOriginalFilename(), destination));
+                results.add(new FileUploadResult(
+                        file.getOriginalFilename(),
+                        destination,
+                        file.getSize()));
             } catch (IOException e) {
                 log.error("Error saving file {}", file.getOriginalFilename(), e);
             }

--- a/src/main/resources/templates/pages/utils/uploadStatus.html
+++ b/src/main/resources/templates/pages/utils/uploadStatus.html
@@ -8,6 +8,22 @@
 <div>
     <h1>Upload Status</h1>
     <h2>Message : <span th:text="${message}"></span></h2>
+    <table class="ui celled striped table" th:if="${files}">
+        <thead>
+        <tr>
+            <th>File name</th>
+            <th>Size (KB)</th>
+            <th>Location</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr th:each="file : ${files}">
+            <td th:text="${file.fileName}"></td>
+            <td th:text="${#numbers.formatDecimal(file.fileSize / 1024.0, 1, 1)}"></td>
+            <td th:text="${file.location}"></td>
+        </tr>
+        </tbody>
+    </table>
 </div>
 <div th:replace="~{includes/footer :: footer}"></div>
 </body>


### PR DESCRIPTION
## Summary
- show uploaded file details in `uploadStatus.html`
- keep size and location in `FileUploadResult`
- persist file size while saving
- forward uploaded file list to the status view

## Testing
- `mvn test` *(fails: Non-resolvable parent POM because network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684afd019858832e8d542bdd9a89c1d0