### PR TITLE
Replace Semantic UI with Tailwind

### DIFF
--- a/src/main/resources/templates/includes/footer.html
+++ b/src/main/resources/templates/includes/footer.html
@@ -1,5 +1,5 @@
-<div class="ui inverted vertical footer segment form-page" th:fragment="footer">
-  <div class="ui container">
+<div class="bg-gray-800 text-white p-4" th:fragment="footer">
+  <div class="container mx-auto">
     adminSpringBoot 2017. All Rights Reserved -
   </div>
 </div>

--- a/src/main/resources/templates/includes/header.html
+++ b/src/main/resources/templates/includes/header.html
@@ -1,6 +1,5 @@
 <div th:fragment="header(pageTitle)">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.1.7/semantic.min.js"></script>
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.1.7/semantic.min.css" rel="stylesheet" type="text/css"/>
+    <script src="https://cdn.tailwindcss.com"></script>
 
     <link th:href="@{/resources/css/my-test.css}" rel="stylesheet" type="text/css" />
     <script th:src="@{/resources/js/simple-test.js}"></script>

--- a/src/main/resources/templates/includes/navigatorHeader.html
+++ b/src/main/resources/templates/includes/navigatorHeader.html
@@ -1,12 +1,12 @@
 <div class="mainMenu" th:fragment="navigatorHeader(pageTitle)">
-    <div class="ui menu">
+    <div class="menu flex space-x-4 bg-gray-200 p-2">
         <a th:href="@{/}" class="item"><i class="home icon"></i> Home </a>
         <a class="browse item">Browse <i class="dropdown icon"></i></a>
-        <div class="ui fluid popup bottom left transition hidden">
-            <div class="ui four column relaxed divided grid">
+        <div class="popup absolute bg-white border p-4 hidden">
+            <div class="grid grid-cols-4 gap-4">
                 <div class="column" th:each="entry : ${navigationMenu}">
-                    <h4 class="ui header" th:text="${entry.key}"></h4>
-                    <div class="ui link list">
+                    <h4 class="font-bold" th:text="${entry.key}"></h4>
+                    <div class="flex flex-col space-y-1">
                         <a class="item" th:each="item : ${entry.value}" th:href="@{${item.path}}" th:text="${item.label}"></a>
                     </div>
                 </div>
@@ -16,7 +16,7 @@
         <a class="right item"><i class="sign in icon"></i> Sign in </a>
     </div>
 </div>
-<div class="ui secondary menu">
+<div class="flex space-x-2 text-gray-600 my-2">
     <div class="item">
         <a th:href="@{/}">Home</a>&nbsp;>&nbsp;<a id="btitle" th:text="${pageTitle}" href="#"></a>
     </div>
@@ -24,16 +24,16 @@
 <script>
 document.addEventListener('DOMContentLoaded', () => {
     const browse = document.querySelector('.mainMenu .menu .browse');
-    const popup = document.querySelector('.ui.popup');
+    const popup = document.querySelector('.popup');
     let hideTimeout;
     const showPopup = () => {
         clearTimeout(hideTimeout);
-        popup.classList.add('visible');
+        popup.classList.add('block');
         popup.classList.remove('hidden');
     };
     const hidePopup = () => {
         hideTimeout = setTimeout(() => {
-            popup.classList.remove('visible');
+            popup.classList.remove('block');
             popup.classList.add('hidden');
         }, 800);
     };

--- a/src/main/resources/templates/pages/bitso/viewBitso.html
+++ b/src/main/resources/templates/pages/bitso/viewBitso.html
@@ -5,38 +5,38 @@
 </head>
 <body>
 <div th:replace="~{includes/header :: header(pageTitle='Bitso')}"></div>
-<div class="ui image label">
+<div class="flex items-center space-x-2">
     <img th:src="@{/resources/images/criptoCurrency/ethereum.png}">
     <span th:text="${balanceTotalETH}"></span>
 </div>
-<div class="ui image label">
+<div class="flex items-center space-x-2">
     <img th:src="@{/resources/images/criptoCurrency/ripple.png}">
     <span th:text="${balanceTotalXRP}"></span>
 </div>
-<div class="ui image label">
+<div class="flex items-center space-x-2">
     <img th:src="@{/resources/images/criptoCurrency/bitcoin.png}">
     <span th:text="${balanceTotalBTC}"></span>
 </div>
-<div class="ui image label">
+<div class="flex items-center space-x-2">
     <img th:src="@{/resources/images/criptoCurrency/mxn.jpg}">
     <span th:text="${balanceTotalMXN}"></span>
 </div>
-<div class="ui image label">
+<div class="flex items-center space-x-2">
     Comisión TOTAL al finalizar los trade: &nbsp;&nbsp; <b th:text="${comisionTOTAL_MXN}"></b>
 </div>
-<div class="ui top attached tabular menu">
+<div class="menu flex border-b space-x-4">
     <a class="active item" data-tab="first">Inversión Inicial &nbsp;
-        <span class="ui teal tag label" th:text="${inversionInicialTotalMXN}"></span>
+        <span class="px-2 py-1 bg-teal-500 text-white rounded" th:text="${inversionInicialTotalMXN}"></span>
     </a>
     <a class="item" data-tab="second">Ganancia &nbsp;
-        <span class="ui teal  tag label" th:text="${gananciaTotalMXN_MXN}"></span>
+        <span class="px-2 py-1 bg-teal-500 text-white rounded" th:text="${gananciaTotalMXN_MXN}"></span>
     </a>
     <a class="item" data-tab="third">Balance Total &nbsp;
-        <span class="ui teal tag label" th:text="${balanceTotal_MXN}"></span>
+        <span class="px-2 py-1 bg-teal-500 text-white rounded" th:text="${balanceTotal_MXN}"></span>
     </a>
 </div>
-<div class="ui bottom attached active tab segment" data-tab="first">
-    <table class="ui sortable celled table">
+<div class="tab segment block active" data-tab="first">
+    <table class="table-auto border-collapse border border-gray-300 sortable">
         <tr>
             <th>ETH</th>
             <th>XRP</th>
@@ -51,8 +51,8 @@
         </tr>
     </table>
 </div>
-<div class="ui bottom attached tab segment" data-tab="second">
-    <table class="ui sortable celled table">
+<div class="tab segment hidden" data-tab="second">
+    <table class="table-auto border-collapse border border-gray-300 sortable">
         <tr>
             <th>ETH</th>
             <th>XRP</th>
@@ -67,8 +67,8 @@
         </tr>
     </table>
 </div>
-<div class="ui bottom attached tab segment" data-tab="third">
-    <table class="ui sortable celled table">
+<div class="tab segment hidden" data-tab="third">
+    <table class="table-auto border-collapse border border-gray-300 sortable">
         <tr>
             <th>ETH</th>
             <th>XRP</th>

--- a/src/main/resources/templates/pages/bitso/viewBitsoCompra.html
+++ b/src/main/resources/templates/pages/bitso/viewBitsoCompra.html
@@ -5,7 +5,7 @@
 </head>
 <body>
 <div th:replace="~{includes/header :: header(pageTitle='Bitso Compra')}"></div>
-<table id="example" class="ui celled table sortable">
+<table id="example" class="table-auto border-collapse border border-gray-300 sortable">
     <thead>
         <tr>
             <th>BOOK</th>
@@ -17,19 +17,19 @@
     </thead>
     <tbody></tbody>
 </table>
-<div class="ui form">
+<div class="space-y-4">
     <form id="formBitso" th:action="@{/bitso/viewBitso}" method="post" th:object="${formBitsoBalance}">
-        <div class="ten wide field">
+        <div class="w-full space-y-4">
             <p class="msgResult" th:text="${msgResult}"></p>
             <div th:if="${#fields.hasErrors('*')}">
                 <div th:errors="*" class="errorDiv"></div>
             </div>
-            <div class="field">
-                <div class="ui labeled input">
+            <div>
+                <div class="flex items-center space-x-2">
                     <input th:field="*{precioEspeculativoETH}" placeholder="Especular precio ETH en MXN" />
                 </div>
             </div>
-            <input class="ui basic blue button" type="submit" value="Submit" />
+            <input class="px-4 py-2 bg-blue-500 text-white rounded" type="submit" value="Submit" />
         </div>
     </form>
 </div>

--- a/src/main/resources/templates/pages/bitso/viewBitsoOrderBook.html
+++ b/src/main/resources/templates/pages/bitso/viewBitsoOrderBook.html
@@ -5,7 +5,7 @@
 </head>
 <body>
 <div th:replace="~{includes/header :: header(pageTitle='Bitso Order Book')}"></div>
-<table id="orderBookResultCompra" class="ui celled table sortable">
+<table id="orderBookResultCompra" class="table-auto border-collapse border border-gray-300 sortable">
     <thead>
         <tr>
             <th>BOOK</th>
@@ -15,7 +15,7 @@
     </thead>
     <tbody></tbody>
 </table>
-<table id="orderBookResultVenta" class="ui celled table sortable">
+<table id="orderBookResultVenta" class="table-auto border-collapse border border-gray-300 sortable">
     <thead>
         <tr>
             <th>BOOK</th>

--- a/src/main/resources/templates/pages/criptoCurrency/mainCripto.html
+++ b/src/main/resources/templates/pages/criptoCurrency/mainCripto.html
@@ -5,9 +5,9 @@
 </head>
 <body>
 <div th:replace="~{includes/header :: header(pageTitle='CriptoCurrency')}"></div>
-<div class="ui form">
-    <div class="ten wide field">
-        <div class="field">
+<div class="space-y-4">
+    <div class="w-full">
+        <div>
             <label for="search">CriptoCurrency</label>
         </div>
     </div>

--- a/src/main/resources/templates/pages/email/viewSendEmailTest.html
+++ b/src/main/resources/templates/pages/email/viewSendEmailTest.html
@@ -5,9 +5,9 @@
 </head>
 <body>
 <div th:replace="~{includes/header :: header(pageTitle='Send Email Test')}"></div>
-<div class="ui form">
-    <div class="ten wide field">
-        <div class="field">
+<div class="space-y-4">
+    <div class="w-full">
+        <div>
             <label for="search">Search</label>
         </div>
     </div>

--- a/src/main/resources/templates/pages/exercises/viewPalindrome.html
+++ b/src/main/resources/templates/pages/exercises/viewPalindrome.html
@@ -6,19 +6,19 @@
 <body>
 <div th:replace="~{includes/header :: header(pageTitle='View Palindrome')}"></div>
 <p>Validar Palíndromo</p>
-<div class="ui form">
+<div class="space-y-4">
     <form id="palindromeForm" th:action="@{/exercises/viewPalindrome}" method="post" th:object="${palindromeSearchCriteria}">
-        <div class="ten wide field">
+        <div class="w-full space-y-4">
             <p class="msgResult" th:text="${msgResult}"></p>
             <div th:if="${#fields.hasErrors('*')}">
                 <div th:errors="*" class="errorDiv"></div>
             </div>
-            <div class="field">
+            <div>
                 <label for="phrase">Phrase</label>
                 <input id="phrase" th:field="*{phrase}" placeholder="phrase" />
             </div>
-            <div class="field errorField" th:errors="*{phrase}"></div>
-            <input class="ui basic blue button" type="submit" value="Validate Phrase" />
+            <div class="errorField" th:errors="*{phrase}"></div>
+            <input class="px-4 py-2 bg-blue-500 text-white rounded" type="submit" value="Validate Phrase" />
         </div>
     </form>
 </div>

--- a/src/main/resources/templates/pages/exercises/viewSerializable.html
+++ b/src/main/resources/templates/pages/exercises/viewSerializable.html
@@ -5,17 +5,17 @@
 </head>
 <body>
 <div th:replace="~{includes/header :: header(pageTitle='Serializable Example')}"></div>
-<div class="ui form">
+<div class="space-y-4">
     <form th:action="@{/exercises/viewSerializable}" method="post" th:object="${serializableGeneralSearchCriteria}">
-        <div class="ten wide field">
+        <div class="w-full space-y-4">
             <div th:if="${#fields.hasErrors('*')}">
                 <div th:errors="*" class="errorDiv"></div>
             </div>
-            <div class="field">
+            <div>
                 <label for="search">Search</label>
                 <input type="text" id="search" th:field="*{search}" placeholder="Search" />
             </div>
-            <input class="ui basic blue button" type="submit" value="Submit" />
+            <input class="px-4 py-2 bg-blue-500 text-white rounded" type="submit" value="Submit" />
         </div>
     </form>
 </div>

--- a/src/main/resources/templates/pages/twilio/viewTwilioSMS.html
+++ b/src/main/resources/templates/pages/twilio/viewTwilioSMS.html
@@ -5,25 +5,25 @@
 </head>
 <body>
 <div th:replace="~{includes/header :: header(pageTitle='Twilio SMS')}"></div>
-<div class="ui form">
+<div class="space-y-4">
     <form id="formTwilio" th:action="@{/twilio/viewTiwilioSMS}" method="post" th:object="${twilioSMSSearchCriteria}">
-        <div class="ten wide field">
+        <div class="w-full space-y-4">
             <p class="msgResult" th:text="${msgResult}"></p>
             <div th:if="${#fields.hasErrors('*')}">
                 <div th:errors="*" class="errorDiv"></div>
             </div>
-            <div class="field">
+            <div>
                 <label for="phoneNumberTo">Phone Number To</label>
-                <div class="ui labeled input">
-                    <div title="For now, only Mexico" class="ui label">+521</div>
+                <div class="flex items-center space-x-2">
+                    <div title="For now, only Mexico" class="px-2 py-1 bg-gray-200 rounded">+521</div>
                     <input th:field="*{phoneNumberTo}" />
                 </div>
             </div>
-            <div class="field">
+            <div>
                 <label for="message">Message</label>
                 <textarea th:field="*{body}" rows="5" cols="30" placeholder="Message"></textarea>
             </div>
-            <input class="ui basic blue button" type="submit" value="Submit" />
+            <input class="px-4 py-2 bg-blue-500 text-white rounded" type="submit" value="Submit" />
         </div>
     </form>
 </div>

--- a/src/main/resources/templates/pages/utils/upload.html
+++ b/src/main/resources/templates/pages/utils/upload.html
@@ -6,7 +6,7 @@
 <body>
 <div th:replace="~{includes/header :: header(pageTitle='Upload Files')}"></div>
 <h1>Spring MVC multi files upload example</h1>
-<div class="ui form">
+<div class="space-y-4">
     <form method="POST" th:action="@{/upload}" th:object="${uploadForm}" enctype="multipart/form-data">
         <input type="file" name="files" /><br/>
         <input type="file" name="files" /><br/>

--- a/src/main/resources/templates/pages/utils/uploadStatus.html
+++ b/src/main/resources/templates/pages/utils/uploadStatus.html
@@ -8,7 +8,7 @@
 <div>
     <h1>Upload Status</h1>
     <h2>Message : <span th:text="${message}"></span></h2>
-    <table class="ui celled striped table" th:if="${files}">
+    <table class="table-auto border-collapse border border-gray-300 striped" th:if="${files}">
         <thead>
         <tr>
             <th>File name</th>


### PR DESCRIPTION
## Summary
- remove Semantic UI references
- add Tailwind CSS via CDN
- adjust templates to stop using Semantic UI classes

## Testing
- `mvn package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b57f2aacc832e9b545523c8562ffc