### PR TITLE
Fix commons-io version for POI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,11 +92,17 @@
 			<artifactId>commons-lang3</artifactId>
 			<version>3.10</version>
 		</dependency>
-		<dependency>
-			<groupId>commons-fileupload</groupId>
-			<artifactId>commons-fileupload</artifactId>
-			<version>1.5</version>
-		</dependency>
+                <dependency>
+                        <groupId>commons-fileupload</groupId>
+                        <artifactId>commons-fileupload</artifactId>
+                        <version>1.5</version>
+                </dependency>
+                <!-- Apache Commons IO required by Apache POI -->
+                <dependency>
+                        <groupId>commons-io</groupId>
+                        <artifactId>commons-io</artifactId>
+                        <version>2.19.0</version>
+                </dependency>
 
 		<!-- Log -->
 		<dependency>


### PR DESCRIPTION
## Summary
- add explicit commons-io dependency so Apache POI runs with required classes

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_684b5c5f0e84832e9860fdebd4c27d07