### PR TITLE
Fix PDF generation directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Se necesita JDK 21 para compilar y ejecutar el proyecto.
 
 La generación de reportes ahora se realiza usando la biblioteca **OpenHTML to PDF**.
 Desde el menú *Browse* selecciona "PDF Reports" para crear un archivo en
-`C:\tools\sample_report.pdf` a partir de una plantilla HTML sencilla.
+`<usuario>/tools/sample_report.pdf` (carpeta `tools` dentro del directorio de usuario)
+a partir de una plantilla HTML sencilla.
 
 

--- a/src/main/java/com/fd/mvc/controller/PdfReportWebController.java
+++ b/src/main/java/com/fd/mvc/controller/PdfReportWebController.java
@@ -7,8 +7,10 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-import java.io.FileOutputStream;
 import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -47,7 +49,15 @@ public class PdfReportWebController {
         parameters.put("DATE_REPORT", LocalDate.now().toString());
         parameters.put("PERSON_LIST", dataList);
 
-        try (OutputStream os = new FileOutputStream("C://tools/sample_report.pdf")) {
+        Path pdfDir = Paths.get(System.getProperty("user.home"), "tools");
+        try {
+            Files.createDirectories(pdfDir);
+        } catch (Exception e) {
+            log.error("Error creating directory for PDF", e);
+        }
+
+        Path pdfPath = pdfDir.resolve("sample_report.pdf");
+        try (OutputStream os = Files.newOutputStream(pdfPath)) {
             String html = "<html><head><meta charset='UTF-8'></head><body>" +
                     "<h1>" + parameters.get("TITLE_REPORT") + "</h1>" +
                     "<p>Fecha: " + parameters.get("DATE_REPORT") + "</p>" +

--- a/src/main/resources/templates/pages/reports/viewPdfReport.html
+++ b/src/main/resources/templates/pages/reports/viewPdfReport.html
@@ -5,7 +5,7 @@
 </head>
 <body>
 <div th:replace="~{includes/header :: header(pageTitle='PDF Report')}"></div>
-<h1>OK - PDF generado, revisa en : C:\tools</h1>
+<h1>OK - PDF generado, revisa en : carpeta "tools" de tu directorio de usuario</h1>
 <div th:replace="~{includes/footer :: footer}"></div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- generate PDF in user's `tools` directory instead of `C:\tools`
- update docs and template with new PDF path

## Testing
- `mvn test` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684b7572da30832ea8f0b1d3c13f08ef